### PR TITLE
Add separate development scripts

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,5 +11,5 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 18.x
         cache: pnpm

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dist"
   ],
   "scripts": {
+    "benchmark": "pnpm vitest bench",
     "build": "tsup",
     "build:contracts": "cd __tests__/contracts && pnpm run build",
     "clean": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && find . -name 'pnpm-lock.yaml' -type f -prune -exec rm -rf '{}' +",
@@ -75,7 +76,7 @@
     "vitest": "^1.5.2"
   },
   "engines": {
-    "node": "20.x",
+    "node": "18.x",
     "pnpm": "8.x"
   },
   "publishConfig": {


### PR DESCRIPTION
Add separate scripts for quickly spinning up a development node and deploying contracts.

Recommend node version `20.x` instead of `18.x` to be consistent with GitHub actions.