### PR TITLE
Fix keySchema and propertiesSchema

### DIFF
--- a/src/tables/contract/types.ts
+++ b/src/tables/contract/types.ts
@@ -58,8 +58,8 @@ export type ContractTable<
     readonly metadata: M & {
       readonly name: tableDef["name"];
       readonly globalName: `${tableDef["namespace"]}__${tableDef["name"]}`;
-      readonly keySchema: KS;
-      readonly propertiesSchema: PS;
+      readonly keySchema: tableDef["keySchema"];
+      readonly propertiesSchema: tableDef["valueSchema"];
     };
   };
 


### PR DESCRIPTION
Fix `keySchema` and `propertiesSchema` incorrectly cast to TypeScript (RECS) types in `ContractTable` type, when it should remain abi types.