### PR TITLE
Clean up dependencies and optimize

### DIFF
--- a/__tests__/utils/index.ts
+++ b/__tests__/utils/index.ts
@@ -1,5 +1,5 @@
-import { Schema } from "@/lib";
-import { BaseTable, BaseTableMetadata, Table } from "@/tables";
+import { BaseTable, Table } from "@/tables";
+import { BaseTableMetadata, Schema } from "@/lib";
 
 export * from "./networkConfig";
 export * from "./actions";

--- a/src/adapter/createStorageAdapter.ts
+++ b/src/adapter/createStorageAdapter.ts
@@ -4,9 +4,10 @@ import { Write } from "@primodiumxyz/sync-stack";
 
 import { decodePropertiesArgs } from "@/adapter/decodeProperties";
 import type { StorageAdapterLog } from "@/adapter/types";
-import type { ContractTable, ContractTables, Properties } from "@/tables/types";
+import type { ContractTable, ContractTables } from "@/tables/types";
 import { resourceToLabel } from "@/lib/external/mud/common";
 import { hexKeyTupleToEntity } from "@/lib/external/mud/entity";
+import type { Properties } from "@/lib/external/mud/schema";
 import type { ContractTableDef, ContractTableDefs } from "@/lib/definitions";
 import { debug } from "@/lib/debug";
 

--- a/src/adapter/decodeProperties.ts
+++ b/src/adapter/decodeProperties.ts
@@ -17,8 +17,7 @@ import {
 } from "@latticexyz/schema-type/internal";
 import { type Hex } from "viem";
 
-import type { Properties } from "@/tables/types";
-import type { AbiPropertiesSchema, AbiToSchema } from "@/lib/external/mud/schema";
+import type { AbiPropertiesSchema, AbiToSchema, Properties } from "@/lib/external/mud/schema";
 
 // Modified from https://github.com/latticexyz/mud/blob/ade94a7fa761070719bcd4b4dac6cb8cc7783c3b/packages/protocol-parser/src/decodePropertiesArgs.ts#L8
 

--- a/src/createWrapper.ts
+++ b/src/createWrapper.ts
@@ -12,10 +12,6 @@ import {
   type World,
 } from "@/lib";
 
-// (jsdocs)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createLocalTable } from "@/tables";
-
 /**
  * Defines the options for creating a TinyBase wrapper.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,15 @@ export type {
   AbiPropertiesSchema,
   AbiToSchema,
   AllTableDefs,
+  BaseTableMetadata,
   ContractTableDef,
   ContractTableDefs,
+  ContractTableMetadata,
   Metadata,
   Entity,
   EntitySymbol,
+  Properties,
+  PropertiesSansMetadata,
   Schema,
   StoreConfig,
   World,
@@ -31,16 +35,4 @@ export { createWorld, namespaceWorld, Type } from "@/lib";
 export type { QueryOptions, TableWatcherCallbacks, TableUpdate, UpdateType } from "@/queries";
 export type { StorageAdapter } from "@/adapter";
 
-export type {
-  BaseTable,
-  BaseTableMetadata,
-  ContractTable,
-  ContractTables,
-  ContractTableMetadata,
-  IndexedBaseTable,
-  Properties,
-  PropertiesSansMetadata,
-  Table,
-  Tables,
-  TableOptions,
-} from "@/tables";
+export type { BaseTable, ContractTable, ContractTables, IndexedBaseTable, Table, Tables, TableOptions } from "@/tables";

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,16 @@ export type {
 } from "@/lib";
 export { createWorld, namespaceWorld, Type } from "@/lib";
 
-export type { QueryOptions, TableWatcherCallbacks, TableUpdate, UpdateType } from "@/queries";
 export type { StorageAdapter } from "@/adapter";
-
-export type { BaseTable, ContractTable, ContractTables, IndexedBaseTable, Table, Tables, TableOptions } from "@/tables";
+export type { QueryOptions, TableWatcherCallbacks } from "@/queries";
+export type {
+  BaseTable,
+  ContractTable,
+  ContractTables,
+  IndexedBaseTable,
+  Table,
+  Tables,
+  TableOptions,
+  TableUpdate,
+  UpdateType,
+} from "@/tables";

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -28,10 +28,6 @@ export type ContractTableDef = MUDTableDef;
  */
 export type ContractTableDefs = { [key: string]: ContractTableDef };
 
-// (jsdocs)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { WrapperOptions } from "@/createWrapper";
-
 // Import and resolve MUD base store & world tables definitions
 import storeConfig from "@latticexyz/store/mud.config";
 import worldConfig from "@latticexyz/world/mud.config";

--- a/src/lib/external/mud/entity.ts
+++ b/src/lib/external/mud/entity.ts
@@ -1,11 +1,6 @@
 import { concatHex, decodeAbiParameters, encodeAbiParameters, type Hex, isHex, size, sliceHex } from "viem";
 
-import type { Properties } from "@/tables/types";
-import type { AbiToSchema, AbiKeySchema, SchemaToPrimitives } from "@/lib/external/mud/schema";
-
-// (jsdocs)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createTableKeyMethods } from "@/tables";
+import type { AbiToSchema, AbiKeySchema, Properties, SchemaToPrimitives } from "@/lib/external/mud/schema";
 
 /**
  * An entity is a string that represents a tuple of hex keys, to identify a row in a table.

--- a/src/lib/external/mud/entity.ts
+++ b/src/lib/external/mud/entity.ts
@@ -1,6 +1,4 @@
-import { concatHex, decodeAbiParameters, encodeAbiParameters, type Hex, isHex, size, sliceHex } from "viem";
-
-import type { AbiToSchema, AbiKeySchema, Properties, SchemaToPrimitives } from "@/lib/external/mud/schema";
+import { concatHex, type Hex, isHex, size, sliceHex } from "viem";
 
 /**
  * An entity is a string that represents a tuple of hex keys, to identify a row in a table.
@@ -51,57 +49,6 @@ export function entityToHexKeyTuple(entity: Entity): readonly Hex[] {
   }
   return new Array(length / 32).fill(0).map((_, index) => sliceHex(entity, index * 32, (index + 1) * 32));
 }
-
-// Valid keys to use as schema
-
-/**
- * Concatenate a tuple of hex keys into a single entity, after encoding them into hex strings.
- *
- * Note: This is especially useful when trying to retrieve an entity using its separate key properties, as it is done in the table key
- * methods attached to contract tables (see {@link createTableKeyMethods}).
- *
- * @category Entity
- */
-export const encodeEntity = <TKeySchema extends AbiKeySchema, T = unknown>(
-  abiKeySchema: TKeySchema,
-  keys: Properties<AbiToSchema<TKeySchema>, T>,
-) => {
-  if (Object.keys(abiKeySchema).length !== Object.keys(keys).length) {
-    throw new Error(
-      `entity length ${Object.keys(keys).length} does not match entity schema length ${Object.keys(abiKeySchema).length}`,
-    );
-  }
-
-  return hexKeyTupleToEntity(
-    Object.entries(abiKeySchema).map(([keyName, type]) => encodeAbiParameters([{ type }], [keys[keyName]])),
-  );
-};
-
-/**
- * Decode an entity into a tuple of hex keys, after decoding them from hex strings.
- *
- * Note: This is useful for retrieving the values of each separate key property from an entity, using its schema and actual entity string.
- *
- * @category Entity
- */
-export const decodeEntity = <TKeySchema extends AbiKeySchema>(
-  abiKeySchema: TKeySchema,
-  entity: Entity,
-): SchemaToPrimitives<TKeySchema> => {
-  const hexKeyTuple = entityToHexKeyTuple(entity);
-  if (hexKeyTuple.length !== Object.keys(abiKeySchema).length) {
-    throw new Error(
-      `entity entity tuple length ${hexKeyTuple.length} does not match entity schema length ${Object.keys(abiKeySchema).length}`,
-    );
-  }
-
-  return Object.fromEntries(
-    Object.entries(abiKeySchema).map(([entity, type], index) => [
-      entity,
-      decodeAbiParameters([{ type }], hexKeyTuple[index] as Hex)[0],
-    ]),
-  ) as SchemaToPrimitives<TKeySchema>;
-};
 
 /**
  * Get the symbol corresponding to an entity's hex ID.

--- a/src/lib/external/mud/indexer.ts
+++ b/src/lib/external/mud/indexer.ts
@@ -1,6 +1,6 @@
-import type { BaseTable, BaseTableMetadata, Properties } from "@/tables/types";
+import type { BaseTable } from "@/tables/types";
 import { type Entity, type EntitySymbol, getEntityHex, getEntitySymbol } from "@/lib/external/mud/entity";
-import type { Schema } from "@/lib/external/mud/schema";
+import type { Schema, BaseTableMetadata, Properties } from "@/lib/external/mud/schema";
 import { tableOperations } from "@/lib/external/mud/tables";
 
 /**

--- a/src/lib/external/mud/queries.ts
+++ b/src/lib/external/mud/queries.ts
@@ -16,8 +16,7 @@ import { observable, ObservableSet } from "mobx";
 import isEqual from "fast-deep-equal";
 import { useEffect, useMemo, useState } from "react";
 
-import type { TableUpdate } from "@/queries/types";
-import type { BaseTable } from "@/tables/types";
+import type { BaseTable, TableUpdate } from "@/tables/types";
 import type { Entity } from "@/lib/external/mud/entity";
 import { type Properties, type Schema, Type } from "@/lib/external/mud/schema";
 import { tableOperations } from "@/lib/external/mud/tables";

--- a/src/lib/external/mud/queries.ts
+++ b/src/lib/external/mud/queries.ts
@@ -17,9 +17,9 @@ import isEqual from "fast-deep-equal";
 import { useEffect, useMemo, useState } from "react";
 
 import type { TableUpdate } from "@/queries/types";
-import type { BaseTable, Properties } from "@/tables/types";
+import type { BaseTable } from "@/tables/types";
 import type { Entity } from "@/lib/external/mud/entity";
-import { type Schema, Type } from "@/lib/external/mud/schema";
+import { type Properties, type Schema, Type } from "@/lib/external/mud/schema";
 import { tableOperations } from "@/lib/external/mud/tables";
 const {
   hasEntity,

--- a/src/lib/external/mud/systems.ts
+++ b/src/lib/external/mud/systems.ts
@@ -1,7 +1,7 @@
 import { concat, EMPTY, from, Observable } from "rxjs";
 
-import type { BaseTable } from "@/tables/types";
-import type { TableUpdate, TableWatcherParams } from "@/queries/types";
+import type { BaseTable, TableUpdate } from "@/tables/types";
+import type { TableWatcherParams } from "@/queries/types";
 import type { Entity } from "@/lib/external/mud/entity";
 import { queries, type QueryFragment } from "@/lib/external/mud/queries";
 import type { Properties, Schema } from "@/lib/external/mud/schema";

--- a/src/lib/external/mud/systems.ts
+++ b/src/lib/external/mud/systems.ts
@@ -1,10 +1,10 @@
 import { concat, EMPTY, from, Observable } from "rxjs";
 
-import type { BaseTable, Properties } from "@/tables/types";
+import type { BaseTable } from "@/tables/types";
 import type { TableUpdate, TableWatcherParams } from "@/queries/types";
 import type { Entity } from "@/lib/external/mud/entity";
 import { queries, type QueryFragment } from "@/lib/external/mud/queries";
-import type { Schema } from "@/lib/external/mud/schema";
+import type { Properties, Schema } from "@/lib/external/mud/schema";
 import { tableOperations } from "@/lib/external/mud/tables";
 import type { World } from "@/lib/external/mud/world";
 const { getTableEntities, setEntity, removeEntity, toUpdateStream } = tableOperations;

--- a/src/lib/external/mud/tables.ts
+++ b/src/lib/external/mud/tables.ts
@@ -1,10 +1,10 @@
 import { map, pipe } from "rxjs";
 import isEqual from "fast-deep-equal";
 
-import type { BaseTableMetadata, IndexedBaseTable, Properties, BaseTable } from "@/tables/types";
+import type { IndexedBaseTable, BaseTable } from "@/tables/types";
 import type { TableUpdate } from "@/queries/types";
 import { getEntitySymbol, type Entity } from "@/lib/external/mud/entity";
-import { OptionalTypes, type Schema } from "@/lib/external/mud/schema";
+import { type BaseTableMetadata, OptionalTypes, type Properties, type Schema } from "@/lib/external/mud/schema";
 
 export type TableMutationOptions = {
   skipUpdateStream?: boolean;

--- a/src/lib/external/mud/tables.ts
+++ b/src/lib/external/mud/tables.ts
@@ -1,14 +1,10 @@
 import { map, pipe } from "rxjs";
 import isEqual from "fast-deep-equal";
 
-import type { IndexedBaseTable, BaseTable } from "@/tables/types";
+import type { IndexedBaseTable, BaseTable, TableMutationOptions } from "@/tables/types";
 import type { TableUpdate } from "@/queries/types";
-import { getEntitySymbol, type Entity } from "@/lib/external/mud/entity";
+import { type Entity, getEntitySymbol } from "@/lib/external/mud/entity";
 import { type BaseTableMetadata, OptionalTypes, type Properties, type Schema } from "@/lib/external/mud/schema";
-
-export type TableMutationOptions = {
-  skipUpdateStream?: boolean;
-};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getTableName(table: BaseTable<any, any, any>) {

--- a/src/lib/external/mud/tables.ts
+++ b/src/lib/external/mud/tables.ts
@@ -1,8 +1,7 @@
 import { map, pipe } from "rxjs";
 import isEqual from "fast-deep-equal";
 
-import type { IndexedBaseTable, BaseTable, TableMutationOptions } from "@/tables/types";
-import type { TableUpdate } from "@/queries/types";
+import type { IndexedBaseTable, BaseTable, TableMutationOptions, TableUpdate } from "@/tables/types";
 import { type Entity, getEntitySymbol } from "@/lib/external/mud/entity";
 import { type BaseTableMetadata, OptionalTypes, type Properties, type Schema } from "@/lib/external/mud/schema";
 

--- a/src/lib/external/mud/tables.ts
+++ b/src/lib/external/mud/tables.ts
@@ -1,7 +1,7 @@
 import { map, pipe } from "rxjs";
 import isEqual from "fast-deep-equal";
 
-import type { IndexedBaseTable, BaseTable, TableMutationOptions, TableUpdate } from "@/tables/types";
+import type { BaseTable, IndexedBaseTable, TableMutationOptions, TableUpdate } from "@/tables/types";
 import { type Entity, getEntitySymbol } from "@/lib/external/mud/entity";
 import { type BaseTableMetadata, OptionalTypes, type Properties, type Schema } from "@/lib/external/mud/schema";
 

--- a/src/lib/external/mud/world.ts
+++ b/src/lib/external/mud/world.ts
@@ -1,5 +1,5 @@
 import type { BaseTable } from "@/tables/types";
-import { getEntityHex, getEntitySymbol, type Entity, type EntitySymbol } from "@/lib/external/mud/entity";
+import { type Entity, type EntitySymbol, getEntityHex, getEntitySymbol } from "@/lib/external/mud/entity";
 import { tableOperations } from "@/lib/external/mud/tables";
 import { transformIterator } from "@/lib/external/mud/utils";
 const { hasEntity: tableHasEntity, removeEntity: tableRemoveEntity } = tableOperations;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,12 +4,13 @@ export * from "@/lib/external/mud/entity";
 export * from "@/lib/external/mud/indexer";
 export * from "@/lib/external/mud/schema";
 export * from "@/lib/external/mud/utils";
-export * from "@/lib/external/uuid";
 
 export * from "@/lib/external/mud/tables";
 export * from "@/lib/external/mud/queries";
 export * from "@/lib/external/mud/systems";
 export * from "@/lib/external/mud/world";
+
+export * from "@/lib/external/uuid";
 
 /* -------------------------------- INTERNAL -------------------------------- */
 export * from "@/lib/constants";

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -1,6 +1,6 @@
-import type { BaseTable, BaseTableMetadata, Properties, Table } from "@/tables/types";
+import type { BaseTable, Table } from "@/tables/types";
 import type { Entity } from "@/lib/external/mud/entity";
-import type { Schema } from "@/lib/external/mud/schema";
+import type { BaseTableMetadata, Properties, Schema } from "@/lib/external/mud/schema";
 import type { World } from "@/lib/external/mud/world";
 
 /* --------------------------------- GLOBAL --------------------------------- */

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -1,41 +1,11 @@
-import type { BaseTable, Table } from "@/tables/types";
-import type { Entity } from "@/lib/external/mud/entity";
+import type { BaseTable, Table, TableUpdate } from "@/tables/types";
 import type { BaseTableMetadata, Properties, Schema } from "@/lib/external/mud/schema";
 import type { World } from "@/lib/external/mud/world";
 
-/* --------------------------------- GLOBAL --------------------------------- */
-/**
- * Defines the type of update for an entity inside a specific table.
- *
- * - `enter` - The entity is now matching the query (or entering the table being watched).
- * - `exit` - The entity is no longer matching the query (or exiting the table being watched).
- * - `change` - The entity is still matching the query (or inside the table), but its properties have changed.
- * - `noop` - No change has occurred.
- * @category Queries
- */
-export type UpdateType = "enter" | "exit" | "change" | "noop";
+/* -------------------------------------------------------------------------- */
+/*                                   WATCHER                                  */
+/* -------------------------------------------------------------------------- */
 
-/**
- * Defines the characteristics of a table update.
- * @template PS The schema of the properties for all entities inside the table being watched.
- * @template M The metadata of the table.
- * @template T The type of the properties to match.
- * @param table The table subject to change (usually without methods, except if ran on init).
- * If the query covers multiple tables, and `runOnInit` is set to `true` (see {@link CreateTableWatcherOptions}), this will be `undefined`.
- * @param entity The entity for which the update has occurred.
- * @param properties The properties of the entity before and after the update (whatever is available).
- * If the entity is entering the query, `prev` will be `undefined`. If the entity is exiting the query, `current` will be `undefined`.
- * @param type The type of update that has occurred (see {@link UpdateType}).
- * @category Queries
- */
-export type TableUpdate<PS extends Schema = Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> = {
-  table: BaseTable<PS, M, T> | Table<PS, M, T>;
-  entity: Entity;
-  properties: { current: Properties<PS, T> | undefined; prev: Properties<PS, T> | undefined };
-  type: UpdateType;
-};
-
-/* --------------------------------- WATCHER -------------------------------- */
 /**
  * Defines the options for watching entities inside a specific table.
  *
@@ -97,7 +67,10 @@ export type TableWatcherParams = {
   runOnInit?: boolean;
 };
 
-/* ---------------------------------- QUERY --------------------------------- */
+/* -------------------------------------------------------------------------- */
+/*                                    QUERY                                   */
+/* -------------------------------------------------------------------------- */
+
 /**
  * Defines a query for entities matching properties for a specific table.
  * @template tableDef The definition of the contract table.

--- a/src/queries/useQuery.ts
+++ b/src/queries/useQuery.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { QueryOptions, TableWatcherCallbacks, TableUpdate, TableWatcherParams } from "@/queries/types";
+import type { TableUpdate } from "@/tables/types";
+import type { QueryOptions, TableWatcherCallbacks, TableWatcherParams } from "@/queries/types";
 import { type Entity } from "@/lib/external/mud/entity";
 import { queries, QueryFragmentType, useDeepMemo } from "@/lib/external/mud/queries";
 import { tableOperations } from "@/lib/external/mud/tables";

--- a/src/tables/core/createLocalTable.ts
+++ b/src/tables/core/createLocalTable.ts
@@ -1,7 +1,7 @@
 import { createTable, type TableOptions } from "@/tables/core/createTable";
-import type { BaseTableMetadata, Table } from "@/tables/types";
+import type { Table } from "@/tables/types";
 import type { World } from "@/lib/external/mud/world";
-import { type Schema, Type } from "@/lib/external/mud/schema";
+import { type BaseTableMetadata, type Schema, Type } from "@/lib/external/mud/schema";
 import { uuid } from "@/lib/external/uuid";
 
 /**

--- a/src/tables/core/createTable.ts
+++ b/src/tables/core/createTable.ts
@@ -1,7 +1,7 @@
 import { Subject } from "rxjs";
 
 import { createTableMethods } from "@/tables/methods/createTableMethods";
-import { type Table, type BaseTable } from "@/tables/types";
+import type { Table, BaseTable } from "@/tables/types";
 import { type EntitySymbol, getEntityHex } from "@/lib/external/mud/entity";
 import { createIndexer } from "@/lib/external/mud/indexer";
 import type { BaseTableMetadata, Schema } from "@/lib/external/mud/schema";

--- a/src/tables/core/createTable.ts
+++ b/src/tables/core/createTable.ts
@@ -1,10 +1,10 @@
 import { Subject } from "rxjs";
 
 import { createTableMethods } from "@/tables/methods/createTableMethods";
-import { type BaseTableMetadata, type Table, type BaseTable } from "@/tables/types";
+import { type Table, type BaseTable } from "@/tables/types";
 import { getEntityHex, type EntitySymbol } from "@/lib/external/mud/entity";
 import { createIndexer } from "@/lib/external/mud/indexer";
-import type { Schema } from "@/lib/external/mud/schema";
+import type { BaseTableMetadata, Schema } from "@/lib/external/mud/schema";
 import { mapObject, transformIterator } from "@/lib/external/mud/utils";
 import type { World } from "@/lib/external/mud/world";
 import { uuid } from "@/lib/external/uuid";

--- a/src/tables/core/createTable.ts
+++ b/src/tables/core/createTable.ts
@@ -2,7 +2,7 @@ import { Subject } from "rxjs";
 
 import { createTableMethods } from "@/tables/methods/createTableMethods";
 import { type Table, type BaseTable } from "@/tables/types";
-import { getEntityHex, type EntitySymbol } from "@/lib/external/mud/entity";
+import { type EntitySymbol, getEntityHex } from "@/lib/external/mud/entity";
 import { createIndexer } from "@/lib/external/mud/indexer";
 import type { BaseTableMetadata, Schema } from "@/lib/external/mud/schema";
 import { mapObject, transformIterator } from "@/lib/external/mud/utils";

--- a/src/tables/methods/createTableKeyMethods.ts
+++ b/src/tables/methods/createTableKeyMethods.ts
@@ -1,5 +1,6 @@
 import type { BaseTable, TableBaseMethods, TableWithKeysMethods } from "@/tables/types";
-import { decodeEntity, encodeEntity, defaultEntity, type Entity } from "@/lib/external/mud/entity";
+import { defaultEntity, type Entity } from "@/lib/external/mud/entity";
+import { decodeEntity, encodeEntity } from "@/lib/external/mud/schema";
 import type { BaseTableMetadata, Keys, Properties, PropertiesSansMetadata, Schema } from "@/lib/external/mud/schema";
 
 /**

--- a/src/tables/methods/createTableKeyMethods.ts
+++ b/src/tables/methods/createTableKeyMethods.ts
@@ -1,14 +1,6 @@
-import type {
-  BaseTable,
-  BaseTableMetadata,
-  Keys,
-  Properties,
-  PropertiesSansMetadata,
-  TableBaseMethods,
-  TableWithKeysMethods,
-} from "@/tables/types";
+import type { BaseTable, TableBaseMethods, TableWithKeysMethods } from "@/tables/types";
 import { decodeEntity, encodeEntity, defaultEntity, type Entity } from "@/lib/external/mud/entity";
-import type { Schema } from "@/lib/external/mud/schema";
+import type { BaseTableMetadata, Keys, Properties, PropertiesSansMetadata, Schema } from "@/lib/external/mud/schema";
 
 /**
  * Create a set of methods to interact with a table using values for its keys properties,

--- a/src/tables/methods/createTableMethods.ts
+++ b/src/tables/methods/createTableMethods.ts
@@ -3,8 +3,8 @@ import { useEffect, useState } from "react";
 
 import { createTableKeyMethods } from "@/tables/methods/createTableKeyMethods";
 import { createTableWatcher } from "@/tables/methods/createTableWatcher";
-import type { BaseTable, TableMethods, TableMutationOptions } from "@/tables/types";
-import { type TableWatcherParams, type TableUpdate, TableMethodsWatcherOptions } from "@/queries/types";
+import type { BaseTable, TableMethods, TableMutationOptions, TableUpdate } from "@/tables/types";
+import { type TableWatcherParams, type TableMethodsWatcherOptions } from "@/queries/types";
 import { defaultEntity, type Entity } from "@/lib/external/mud/entity";
 import type { BaseTableMetadata, Properties, PropertiesSansMetadata, Schema } from "@/lib/external/mud/schema";
 import { tableOperations } from "@/lib/external/mud/tables";

--- a/src/tables/methods/createTableMethods.ts
+++ b/src/tables/methods/createTableMethods.ts
@@ -3,10 +3,10 @@ import { useEffect, useState } from "react";
 
 import { createTableKeyMethods } from "@/tables/methods/createTableKeyMethods";
 import { createTableWatcher } from "@/tables/methods/createTableWatcher";
-import type { BaseTable, BaseTableMetadata, Properties, PropertiesSansMetadata, TableMethods } from "@/tables/types";
+import type { BaseTable, TableMethods } from "@/tables/types";
 import { type TableWatcherParams, type TableUpdate, TableMethodsWatcherOptions } from "@/queries/types";
 import { defaultEntity, type Entity } from "@/lib/external/mud/entity";
-import type { Schema } from "@/lib/external/mud/schema";
+import type { BaseTableMetadata, Properties, PropertiesSansMetadata, Schema } from "@/lib/external/mud/schema";
 import { type TableMutationOptions, tableOperations } from "@/lib/external/mud/tables";
 import { queries } from "@/lib/external/mud/queries";
 import type { World } from "@/lib/external/mud/world";

--- a/src/tables/methods/createTableMethods.ts
+++ b/src/tables/methods/createTableMethods.ts
@@ -3,11 +3,11 @@ import { useEffect, useState } from "react";
 
 import { createTableKeyMethods } from "@/tables/methods/createTableKeyMethods";
 import { createTableWatcher } from "@/tables/methods/createTableWatcher";
-import type { BaseTable, TableMethods } from "@/tables/types";
+import type { BaseTable, TableMethods, TableMutationOptions } from "@/tables/types";
 import { type TableWatcherParams, type TableUpdate, TableMethodsWatcherOptions } from "@/queries/types";
 import { defaultEntity, type Entity } from "@/lib/external/mud/entity";
 import type { BaseTableMetadata, Properties, PropertiesSansMetadata, Schema } from "@/lib/external/mud/schema";
-import { type TableMutationOptions, tableOperations } from "@/lib/external/mud/tables";
+import { tableOperations } from "@/lib/external/mud/tables";
 import { queries } from "@/lib/external/mud/queries";
 import type { World } from "@/lib/external/mud/world";
 const {

--- a/src/tables/methods/createTableWatcher.ts
+++ b/src/tables/methods/createTableWatcher.ts
@@ -1,4 +1,5 @@
-import type { TableWatcherOptions, TableUpdate, TableWatcherParams } from "@/queries/types";
+import type { TableUpdate } from "@/tables/types";
+import type { TableWatcherOptions, TableWatcherParams } from "@/queries/types";
 import type { BaseTableMetadata, Schema } from "@/lib/external/mud/schema";
 import { systems } from "@/lib/external/mud/systems";
 

--- a/src/tables/methods/createTableWatcher.ts
+++ b/src/tables/methods/createTableWatcher.ts
@@ -1,6 +1,5 @@
-import type { BaseTableMetadata } from "@/tables/types";
 import type { TableWatcherOptions, TableUpdate, TableWatcherParams } from "@/queries/types";
-import type { Schema } from "@/lib/external/mud/schema";
+import type { BaseTableMetadata, Schema } from "@/lib/external/mud/schema";
 import { systems } from "@/lib/external/mud/systems";
 
 /**

--- a/src/tables/types.ts
+++ b/src/tables/types.ts
@@ -11,30 +11,9 @@ import type {
   PropertiesSansMetadata,
   Schema,
 } from "@/lib/external/mud/schema";
-import type { TableMutationOptions } from "@/lib/external/mud/tables";
 import type { World } from "@/lib/external/mud/world";
 import type { ContractTableDef } from "@/lib/definitions";
 import type { TableMethodsWatcherOptions, TableUpdate, TableWatcherParams } from "@/queries/types";
-
-export interface BaseTable<PS extends Schema = Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> {
-  id: string;
-  properties: { [key in keyof PS]: Map<EntitySymbol, MappedType<T>[PS[key]]> };
-  propertiesSchema: PS;
-  // keySchema: KS | { entity: Type.Entity }; // default key schema for tables without keys
-  metadata: M;
-  world: World;
-  entities: () => IterableIterator<Entity>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  update$: Subject<TableUpdate<PS, M, T>> & { observers: any };
-}
-
-export type IndexedBaseTable<
-  PS extends Schema = Schema,
-  M extends BaseTableMetadata = BaseTableMetadata,
-  T = unknown,
-> = BaseTable<PS, M, T> & {
-  getEntitiesWithProperties: (properties: Properties<PS, T>) => Set<Entity>;
-};
 
 export type Tables = { [name: string]: Table };
 export type Table<PS extends Schema = Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> = BaseTable<
@@ -52,6 +31,30 @@ export type ContractTable<
   PS extends ContractTablePropertiesSchema<tableDef> = ContractTablePropertiesSchema<tableDef>,
   // KS extends ContractTableKeySchema<tableDef> = ContractTableKeySchema<tableDef>,
 > = Table<PS, ContractTableMetadata<tableDef>>;
+
+export type IndexedBaseTable<
+  PS extends Schema = Schema,
+  M extends BaseTableMetadata = BaseTableMetadata,
+  T = unknown,
+> = BaseTable<PS, M, T> & {
+  getEntitiesWithProperties: (properties: Properties<PS, T>) => Set<Entity>;
+};
+
+export type TableMutationOptions = {
+  skipUpdateStream?: boolean;
+};
+
+export interface BaseTable<PS extends Schema = Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> {
+  id: string;
+  properties: { [key in keyof PS]: Map<EntitySymbol, MappedType<T>[PS[key]]> };
+  propertiesSchema: PS;
+  // keySchema: KS | { entity: Type.Entity }; // default key schema for tables without keys
+  metadata: M;
+  world: World;
+  entities: () => IterableIterator<Entity>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  update$: Subject<TableUpdate<PS, M, T>> & { observers: any };
+}
 
 /**
  * Defines the methods available for any table.

--- a/src/tables/types.ts
+++ b/src/tables/types.ts
@@ -1,18 +1,16 @@
 import { Subject } from "rxjs";
 
-import type { ResourceLabel } from "@/lib/external/mud/common";
 import type { Entity, EntitySymbol } from "@/lib/external/mud/entity";
 import type {
-  AbiKeySchema,
-  AbiToSchema,
+  BaseTableMetadata,
+  ContractTableMetadata,
+  ContractTablePropertiesSchema,
+  Keys,
   MappedType,
-  Metadata,
+  Properties,
+  PropertiesSansMetadata,
   Schema,
-  SchemaAbiType,
-  SchemaAbiTypeToRecsType,
-  StaticAbiType,
 } from "@/lib/external/mud/schema";
-import { Type } from "@/lib/external/mud/schema";
 import type { TableMutationOptions } from "@/lib/external/mud/tables";
 import type { World } from "@/lib/external/mud/world";
 import type { ContractTableDef } from "@/lib/definitions";
@@ -38,13 +36,6 @@ export type IndexedBaseTable<
   getEntitiesWithProperties: (properties: Properties<PS, T>) => Set<Entity>;
 };
 
-export type BaseTableMetadata<M extends Metadata = Metadata> = M & {
-  name: string;
-  globalName: string;
-  namespace?: string;
-  abiKeySchema: { [name: string]: StaticAbiType }; // local tables are given a default key schema as well for encoding/decoding entities
-};
-
 export type Tables = { [name: string]: Table };
 export type Table<PS extends Schema = Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> = BaseTable<
   PS,
@@ -61,47 +52,6 @@ export type ContractTable<
   PS extends ContractTablePropertiesSchema<tableDef> = ContractTablePropertiesSchema<tableDef>,
   // KS extends ContractTableKeySchema<tableDef> = ContractTableKeySchema<tableDef>,
 > = Table<PS, ContractTableMetadata<tableDef>>;
-
-export type ContractTablePropertiesSchema<tableDef extends ContractTableDef> = {
-  __staticData: Type.OptionalHex;
-  __encodedLengths: Type.OptionalHex;
-  __dynamicData: Type.OptionalHex;
-  __lastSyncedAtBlock: Type.OptionalBigInt;
-} & {
-  [fieldName in keyof tableDef["valueSchema"] & string]: Type &
-    SchemaAbiTypeToRecsType<SchemaAbiType & tableDef["valueSchema"][fieldName]["type"]>;
-};
-
-export type ContractTableKeySchema<tableDef extends ContractTableDef> = {
-  [fieldName in keyof tableDef["keySchema"] & string]: Type &
-    SchemaAbiTypeToRecsType<SchemaAbiType & tableDef["keySchema"][fieldName]["type"]>;
-};
-
-export type ContractTableMetadata<tableDef extends ContractTableDef> = {
-  name: tableDef["name"];
-  namespace: tableDef["namespace"];
-  globalName: ResourceLabel;
-  abiPropertiesSchema: { [name in keyof tableDef["valueSchema"] & string]: tableDef["valueSchema"][name]["type"] };
-  abiKeySchema: { [name in keyof tableDef["keySchema"] & string]: tableDef["keySchema"][name]["type"] };
-};
-
-// Used to infer the TypeScript types from the RECS types (from schema)
-export type Properties<S extends Schema, T = unknown> = {
-  [key in keyof S]: MappedType<T>[S[key]];
-};
-
-// Used to infer the TypeScript types from the RECS types (from abi)
-export type Keys<TKeySchema extends AbiKeySchema, T = unknown> = {
-  [key in keyof AbiToSchema<TKeySchema>]: MappedType<T>[AbiToSchema<TKeySchema>[key]];
-};
-
-// Used to infer the TypeScript types from the RECS types (excluding metadata)
-export type PropertiesSansMetadata<S extends Schema, T = unknown> = {
-  [key in keyof S as Exclude<
-    key,
-    "__staticData" | "__encodedLengths" | "__dynamicData" | "__lastSyncedAtBlock"
-  >]: MappedType<T>[S[key]];
-};
 
 /**
  * Defines the methods available for any table.

--- a/src/tables/types.ts
+++ b/src/tables/types.ts
@@ -1,5 +1,6 @@
 import { Subject } from "rxjs";
 
+import type { TableMethodsWatcherOptions, TableWatcherParams } from "@/queries/types";
 import type { Entity, EntitySymbol } from "@/lib/external/mud/entity";
 import type {
   BaseTableMetadata,
@@ -13,12 +14,12 @@ import type {
 } from "@/lib/external/mud/schema";
 import type { World } from "@/lib/external/mud/world";
 import type { ContractTableDef } from "@/lib/definitions";
-import type { TableMethodsWatcherOptions, TableWatcherParams } from "@/queries/types";
 
 /* -------------------------------------------------------------------------- */
-/*                                   GLOBAL                                   */
+/*                                   OBJECT                                   */
 /* -------------------------------------------------------------------------- */
 
+/* --------------------------------- GLOBAL --------------------------------- */
 export type Tables = { [name: string]: Table };
 export type Table<PS extends Schema = Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> = BaseTable<
   PS,
@@ -27,10 +28,7 @@ export type Table<PS extends Schema = Schema, M extends BaseTableMetadata = Base
 > &
   TableMethods<PS, M, T>;
 
-/* -------------------------------------------------------------------------- */
-/*                                  CONTRACT                                  */
-/* -------------------------------------------------------------------------- */
-
+/* -------------------------------- CONTRACT -------------------------------- */
 export type ContractTables<tableDefs extends Record<string, ContractTableDef>> = {
   [name in keyof tableDefs]: ContractTable<tableDefs[name]>;
 };
@@ -41,10 +39,7 @@ export type ContractTable<
   // KS extends ContractTableKeySchema<tableDef> = ContractTableKeySchema<tableDef>,
 > = Table<PS, ContractTableMetadata<tableDef>>;
 
-/* -------------------------------------------------------------------------- */
-/*                                   INDEXED                                  */
-/* -------------------------------------------------------------------------- */
-
+/* --------------------------------- INDEXED -------------------------------- */
 export type IndexedBaseTable<
   PS extends Schema = Schema,
   M extends BaseTableMetadata = BaseTableMetadata,
@@ -53,15 +48,11 @@ export type IndexedBaseTable<
   getEntitiesWithProperties: (properties: Properties<PS, T>) => Set<Entity>;
 };
 
-/* -------------------------------------------------------------------------- */
-/*                                    BASE                                    */
-/* -------------------------------------------------------------------------- */
-
+/* ---------------------------------- BASE ---------------------------------- */
 export interface BaseTable<PS extends Schema = Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> {
   id: string;
   properties: { [key in keyof PS]: Map<EntitySymbol, MappedType<T>[PS[key]]> };
   propertiesSchema: PS;
-  // keySchema: KS | { entity: Type.Entity }; // default key schema for tables without keys
   metadata: M;
   world: World;
   entities: () => IterableIterator<Entity>;
@@ -69,6 +60,11 @@ export interface BaseTable<PS extends Schema = Schema, M extends BaseTableMetada
   update$: Subject<TableUpdate<PS, M, T>> & { observers: any };
 }
 
+/* -------------------------------------------------------------------------- */
+/*                                   METHODS                                  */
+/* -------------------------------------------------------------------------- */
+
+/* -------------------------------- MUTATION -------------------------------- */
 /**
  * Defines the type of update for an entity inside a specific table.
  *
@@ -104,10 +100,7 @@ export type TableMutationOptions = {
   skipUpdateStream?: boolean;
 };
 
-/* -------------------------------------------------------------------------- */
-/*                                   METHODS                                  */
-/* -------------------------------------------------------------------------- */
-
+/* ---------------------------------- TABLE --------------------------------- */
 /**
  * Defines the methods available for any table.
  *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,13 @@ export {
   // Decoding/encoding keys from/into an entity
   decodeEntity,
   encodeEntity,
-  // Concat a tuple of hex keys into a single entity
-  hexKeyTupleToEntity,
   // Convert an entity into a tuple of hex keys
   entityToHexKeyTuple,
+  // Concat a tuple of hex keys into a single entity
+  hexKeyTupleToEntity,
+  // symbol <-> entity
+  getEntityHex,
+  getEntitySymbol,
   // Convert ABI types to TypeScript understandable types
   schemaAbiTypeToRecsType,
   // uuid
@@ -17,4 +20,4 @@ export {
 } from "@/lib";
 
 // Storage adapter
-export { StorageAdapterBlock, StorageAdapterLog } from "@/adapter";
+export type { StorageAdapterBlock, StorageAdapterLog } from "@/adapter";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,17 @@
 {
   "compilerOptions": {
-    "target": "es2021",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM"],
     "declaration": true,
-    "sourceMap": true,
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
     "resolveJsonModule": true,
-    "emitDeclarationOnly": true,
     "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/index.ts",
     utils: "src/utils.ts",
   },
+  external: ["react", "react-dom"],
   outDir: "dist",
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
### 1. Clean up circular dependencies

Clean up dependencies, restructure files to prevent circular dependencies as much as possible. Some might still be there, but that much means that there is something that can be improved in the structure.

This will short-circuit some possible edge-case issues, type errors and inconsistencies during development, and a few type errors that would not be descriptive at all and confusing.

The same should be done for the core package then, which has approximately the same amount of circular dependencies.

_Starting point:_
![image](https://github.com/primodiumxyz/reactive-tables/assets/99199454/17e96ec6-ed46-472d-83d8-c568076e1c41)


_After removing most circular dependencies (the remaining ones making sense as they are):_
![image](https://github.com/primodiumxyz/reactive-tables/assets/99199454/57d463b3-06bf-4905-8867-e19d3bd697cf)


### 2. Optimize

Optimize the package to reduce its size, which is far too much right now (thus improve its type efficiency); which basically *3 the size of the core package before/after integrated with RETA.