### PR TITLE
Add once method

### DIFF
--- a/src/dev/pages/query.tsx
+++ b/src/dev/pages/query.tsx
@@ -266,15 +266,15 @@ const QueryFragmentForm = ({
 
 const QueryFragmentRow = ({
   index,
-  fragment: { with: inside, withProperties, without: outside, withoutProperties },
+  fragment: { with: _with, withProperties, without, withoutProperties },
   onRemove,
 }: {
   index: number;
   fragment: Fragment;
   onRemove?: () => void;
 }) => {
-  const type = inside.length > 0 || withProperties.length > 0 ? "positive" : "negative";
-  const statement = type === "positive" ? inside[0] ?? withProperties[0] : outside[0] ?? withoutProperties[0];
+  const type = _with.length > 0 || withProperties.length > 0 ? "positive" : "negative";
+  const statement = type === "positive" ? _with[0] ?? withProperties[0] : without[0] ?? withoutProperties[0];
   const table = "table" in statement ? (statement.table as Table) : statement;
   const properties = "table" in statement ? statement.properties : undefined;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { defaultEntity, localProperties, metadataProperties } from "@/lib";
 export type {
   AbiKeySchema,
   AbiPropertiesSchema,
+  AdjustedPropertiesSchema,
   UnparsedAbiKeySchema,
   UnparsedAbiPropertiesSchema,
   AbiToSchema,
@@ -27,6 +28,7 @@ export type {
   EntitySymbol,
   Keys,
   Metadata,
+  OptionalSchema,
   OptionalTypes,
   Properties,
   PropertiesSansMetadata,

--- a/src/lib/external/mud/schema.ts
+++ b/src/lib/external/mud/schema.ts
@@ -61,6 +61,8 @@ export type UnparsedAbiPropertiesSchema = {
   };
 };
 
+export type AdjustedPropertiesSchema<PS extends Schema, P extends boolean> = P extends true ? OptionalSchema<PS> : PS;
+
 /* -------------------------------------------------------------------------- */
 /*                                   TABLES                                   */
 /* -------------------------------------------------------------------------- */

--- a/src/lib/external/mud/systems.ts
+++ b/src/lib/external/mud/systems.ts
@@ -1,4 +1,4 @@
-import { concat, EMPTY, from, Observable } from "rxjs";
+import { concat, EMPTY, from, Observable, Subject, takeUntil } from "rxjs";
 
 import type { BaseTable, TableUpdate } from "@/tables/types";
 import type { TableWatcherParams } from "@/queries/types";
@@ -12,6 +12,8 @@ const { defineChangeQuery, defineEnterQuery, defineExitQuery, defineQuery } = qu
 
 // All of the following code is taken and modified from MUD to fit new types and naming conventions.
 
+type Unsuscribe = () => void;
+
 const _systems = () => {
   /**
    * Create a system that is called on every update of the given observable.
@@ -23,10 +25,33 @@ const _systems = () => {
    * @param world {@link World} object this system should be registered in.
    * @param observable$ Observable to react to.
    * @param system System function to run on updates of the `observable$`. System function gets passed the update events from the `observable$`.
+   * @param until Optional: Function to determine if the system should be terminated based on the update.
+   * @returns Function to unsubscribe the system from the `observable$`.
    */
-  const defineRxSystem = <T>(world: World, observable$: Observable<T>, system: (event: T) => void) => {
+  const defineRxSystem = <T>(
+    world: World,
+    observable$: Observable<T>,
+    system: (event: T) => void,
+    until?: (event: T) => boolean,
+  ): Unsuscribe => {
+    // if until is provided, we want to close the sub when it returns true
+    if (until) {
+      const terminate = new Subject<void>();
+      const subscription = observable$.pipe(takeUntil(terminate)).subscribe((update) => {
+        system(update);
+        if (until(update)) {
+          terminate.next();
+          terminate.unsubscribe();
+        }
+      });
+
+      world.registerDisposer(() => subscription?.unsubscribe());
+      return subscription?.unsubscribe;
+    }
+
     const subscription = observable$.subscribe(system);
     world.registerDisposer(() => subscription?.unsubscribe());
+    return subscription?.unsubscribe;
   };
 
   /**
@@ -39,14 +64,15 @@ const _systems = () => {
    * runOnInit: if true, run this system for all entities matching the query when the system is created.
    * Else only run on updates after the system is created. Default true.
    * }
+   * @returns Function to unsubscribe the system from the query.
    */
   const defineUpdateSystem = (
     world: World,
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ) => {
-    defineRxSystem(world, defineChangeQuery(query, options), system);
+  ): Unsuscribe => {
+    return defineRxSystem(world, defineChangeQuery(query, options), system);
   };
 
   /**
@@ -59,14 +85,15 @@ const _systems = () => {
    * runOnInit: if true, run this system for all entities matching the query when the system is created.
    * Else only run on updates after the system is created. Default true.
    * }
+   * @returns Function to unsubscribe the system from the query.
    */
   const defineEnterSystem = (
     world: World,
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ) => {
-    defineRxSystem(world, defineEnterQuery(query, options), system);
+  ): Unsuscribe => {
+    return defineRxSystem(world, defineEnterQuery(query, options), system);
   };
 
   /**
@@ -79,14 +106,15 @@ const _systems = () => {
    * runOnInit: if true, run this system for all entities matching the query when the system is created.
    * Else only run on updates after the system is created. Default true.
    * }
+   * @returns Function to unsubscribe the system from the query.
    */
   const defineExitSystem = (
     world: World,
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ) => {
-    defineRxSystem(world, defineExitQuery(query, options), system);
+  ): Unsuscribe => {
+    return defineRxSystem(world, defineExitQuery(query, options), system);
   };
 
   /**
@@ -99,14 +127,15 @@ const _systems = () => {
    * runOnInit: if true, run this system for all entities matching the query when the system is created.
    * Else only run on updates after the system is created. Default true.
    * }
+   * @returns Function to unsubscribe the system from the query.
    */
   const defineSystem = (
     world: World,
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ) => {
-    defineRxSystem(world, defineQuery(query, options).update$, system);
+  ): Unsuscribe => {
+    return defineRxSystem(world, defineQuery(query, options).update$, system);
   };
 
   /**
@@ -119,15 +148,18 @@ const _systems = () => {
    * runOnInit: if true, run this system for all entities in the table when the system is created.
    * Else only run on updates after the system is created. Default true.
    * }
+   * @param until Optional: Function to determine if the system should be terminated based on the update.
+   * @returns Function to unsubscribe the system from the table.
    */
   const defineTableSystem = <S extends Schema>(
     world: World,
     table: BaseTable<S>,
     system: (update: TableUpdate<S>) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ) => {
+    until?: (update: TableUpdate<S>) => boolean,
+  ): Unsuscribe => {
     const initial$ = options?.runOnInit ? from(getTableEntities(table)).pipe(toUpdateStream(table)) : EMPTY;
-    defineRxSystem(world, concat(initial$, table.update$), system);
+    return defineRxSystem(world, concat(initial$, table.update$), system, until);
   };
 
   /**
@@ -137,6 +169,12 @@ const _systems = () => {
    * @param query Result of `table` is added to all entities matching this query.
    * @param component Function returning the table to be added to all entities matching the given query.
    * @param value Function returning the table properties to be added to all entities matching the given query.
+   * @param options Optional: {
+   * runOnInit: if true, run this system for all entities matching the query when the system is created.
+   * Else only run on updates after the system is created. Default true.
+   * update: if true, run this system on every update of the table, not just on enter and exit. Default false.
+   * }
+   * @returns Function to unsubscribe the system from the query.
    */
   const defineSyncSystem = <S extends Schema>(
     world: World,
@@ -144,8 +182,8 @@ const _systems = () => {
     table: (entity: Entity) => BaseTable<S>,
     properties: (entity: Entity) => Properties<S>,
     options: TableWatcherParams & { update?: boolean } = { runOnInit: true, update: false },
-  ) => {
-    defineSystem(
+  ): Unsuscribe => {
+    return defineSystem(
       world,
       query,
       ({ entity, type }) => {

--- a/src/lib/external/mud/systems.ts
+++ b/src/lib/external/mud/systems.ts
@@ -12,7 +12,7 @@ const { defineChangeQuery, defineEnterQuery, defineExitQuery, defineQuery } = qu
 
 // All of the following code is taken and modified from MUD to fit new types and naming conventions.
 
-type Unsuscribe = () => void;
+type Unsubscribe = () => void;
 
 const _systems = () => {
   /**
@@ -33,7 +33,7 @@ const _systems = () => {
     observable$: Observable<T>,
     system: (event: T) => void,
     until?: (event: T) => boolean,
-  ): Unsuscribe => {
+  ): Unsubscribe => {
     // if until is provided, we want to close the sub when it returns true
     if (until) {
       const terminate = new Subject<void>();
@@ -71,7 +71,7 @@ const _systems = () => {
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ): Unsuscribe => {
+  ): Unsubscribe => {
     return defineRxSystem(world, defineChangeQuery(query, options), system);
   };
 
@@ -92,7 +92,7 @@ const _systems = () => {
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ): Unsuscribe => {
+  ): Unsubscribe => {
     return defineRxSystem(world, defineEnterQuery(query, options), system);
   };
 
@@ -113,7 +113,7 @@ const _systems = () => {
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ): Unsuscribe => {
+  ): Unsubscribe => {
     return defineRxSystem(world, defineExitQuery(query, options), system);
   };
 
@@ -134,7 +134,7 @@ const _systems = () => {
     query: QueryFragment[],
     system: (update: TableUpdate) => void,
     options: TableWatcherParams = { runOnInit: true },
-  ): Unsuscribe => {
+  ): Unsubscribe => {
     return defineRxSystem(world, defineQuery(query, options).update$, system);
   };
 
@@ -157,7 +157,7 @@ const _systems = () => {
     system: (update: TableUpdate<S>) => void,
     options: TableWatcherParams = { runOnInit: true },
     until?: (update: TableUpdate<S>) => boolean,
-  ): Unsuscribe => {
+  ): Unsubscribe => {
     const initial$ = options?.runOnInit ? from(getTableEntities(table)).pipe(toUpdateStream(table)) : EMPTY;
     return defineRxSystem(world, concat(initial$, table.update$), system, until);
   };
@@ -182,7 +182,7 @@ const _systems = () => {
     table: (entity: Entity) => BaseTable<S>,
     properties: (entity: Entity) => Properties<S>,
     options: TableWatcherParams & { update?: boolean } = { runOnInit: true, update: false },
-  ): Unsuscribe => {
+  ): Unsubscribe => {
     return defineSystem(
       world,
       query,

--- a/src/queries/$query.ts
+++ b/src/queries/$query.ts
@@ -17,6 +17,7 @@ import { queryToFragments } from "./utils";
  * @param options The {@link WatcherOptions} with the world object and callbacks to trigger on changes. Including: onUpdate, onEnter, onExit, onChange.
  * These will trigger a {@link TableUpdate} object inside the id of the updated table, the entity, the previous and new properties of the entity and the type of update.
  * @param params (optional) Additional {@link TableWatcherParams} for the query. Currently only supports `runOnInit` to trigger the callbacks for all matching entities on initialization.
+ * @returns Function to unsubscribe from the listener.
  * @example
  * This example creates a query that listens to all entities that represent online players notInside a score of 0.
  *
@@ -47,13 +48,13 @@ export const $query = <tables extends BaseTables | Tables>(
   query: QueryOptions<tables>,
   options: WatcherOptions<tables>,
   params: TableWatcherParams = { runOnInit: true },
-) => {
+): (() => void) => {
   const { world, onUpdate, onEnter, onExit, onChange } = options;
   if (!onUpdate && !onEnter && !onExit && !onChange) {
     throw new Error("At least one callback has to be provided");
   }
 
-  systems.defineSystem(
+  return systems.defineSystem(
     // one will necessarily be defined, otherwise no positive fragment -> will throw
     world ?? query.with?.[0].world ?? query.withProperties?.[0].table.world,
     queryToFragments(query),

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -46,6 +46,12 @@ export type TableMethodsWatcherOptions<
   T = unknown,
 > = Omit<TableWatcherOptions<PS, M, T>, "table">;
 
+export type TableMethodsOnceOptions<PS extends Schema, M extends BaseTableMetadata = BaseTableMetadata, T = unknown> = {
+  filter: (update: TableUpdate<PS, M, T>) => boolean;
+  do: (update: TableUpdate<PS, M, T>) => void;
+  world?: World;
+};
+
 /**
  * Defines the callbacks for a table watcher.
  *

--- a/src/queries/utils.ts
+++ b/src/queries/utils.ts
@@ -25,15 +25,15 @@ export const queryMatchingCondition = <table extends BaseTable>({
 }): QueryMatchingCondition => ({ table, where }) as QueryMatchingCondition;
 
 export const queryToFragments = <tables extends BaseTables>(query: QueryOptions<tables>): QueryFragments => {
-  const { with: inside, without: notInside, withProperties, withoutProperties, matching } = query;
-  if (!inside && !withProperties) {
+  const { with: _with, without, withProperties, withoutProperties, matching } = query;
+  if (!_with && !withProperties) {
     throw new Error("At least one `with` or `withProperties` condition needs to be provided");
   }
 
   return [
-    ...(inside?.map((fragment) => With(fragment)) ?? []),
+    ...(_with?.map((fragment) => With(fragment)) ?? []),
     ...(withProperties?.map((matching) => WithProperties(matching.table, { ...matching.properties })) ?? []),
-    ...(notInside?.map((table) => Without(table)) ?? []),
+    ...(without?.map((table) => Without(table)) ?? []),
     ...(withoutProperties?.map((matching) => WithoutProperties(matching.table, { ...matching.properties })) ?? []),
     ...(matching?.map((matching) => MatchingProperties(matching.table, matching.where)) ?? []),
   ];

--- a/src/tables/core/createContractTables.ts
+++ b/src/tables/core/createContractTables.ts
@@ -51,7 +51,8 @@ export const createContractTables = <config extends StoreConfig, extraTableDefs 
         id: def.tableId,
         metadata: {
           name: def.name, // RECS `componentName`
-          globalName: resourceToLabel(def), // namespaced; RECS `tableName`
+          namespace: def.namespace, // RECS `namespace`
+          globalName: resourceToLabel(def), // namespace + name; RECS `tableName`
           // @ts-expect-error complex union type
           abiKeySchema: mapObject(def.keySchema, ({ type }) => type),
           // @ts-expect-error complex union type

--- a/src/tables/core/createLocalTable.ts
+++ b/src/tables/core/createLocalTable.ts
@@ -2,6 +2,7 @@ import { createTable, type TableOptions } from "@/tables/core/createTable";
 import type { Table } from "@/tables/types";
 import type { World } from "@/lib/external/mud/world";
 import {
+  type AdjustedPropertiesSchema,
   type BaseTableMetadata,
   OptionalSchema,
   type Properties,
@@ -10,8 +11,6 @@ import {
   toOptionalType,
 } from "@/lib/external/mud/schema";
 import { uuid } from "@/lib/external/uuid";
-
-type AdjustedPropertiesSchema<PS extends Schema, P extends boolean> = P extends true ? OptionalSchema<PS> : PS;
 
 /**
  * Creates a local table with the specified properties schema, options and metadata.

--- a/src/tables/core/createTable.ts
+++ b/src/tables/core/createTable.ts
@@ -26,7 +26,7 @@ import { createLocalStorageAdapter, DEFAULT_VERSION, type PersistentStorageAdapt
  */
 export type TableOptions<M extends BaseTableMetadata = BaseTableMetadata, P extends boolean = false> = {
   id?: string; // default: uuid
-  metadata?: M;
+  metadata?: Partial<M>;
   indexed?: boolean;
   persist?: P;
   version?: string;

--- a/src/tables/methods/createTableWatcher.ts
+++ b/src/tables/methods/createTableWatcher.ts
@@ -17,6 +17,7 @@ import { systems } from "@/lib/external/mud/systems";
  * - `onExit` Callback triggered when an entity exits the table/query (`properties.current` will be undefined).
  * - `onChange` Callback triggered on any change in the table/query (encompassing enter, exit, and update).
  * @param params Additional {@link TableWatcherParams} for the watcher.
+ * @returns Function to unsubscribe from the listener.
  * @example
  * This example creates a watcher for all entities within (with properties inside) the "Player" table.
  *
@@ -46,13 +47,13 @@ import { systems } from "@/lib/external/mud/systems";
 export const createTableWatcher = <PS extends Schema, M extends BaseTableMetadata, T = unknown>(
   options: TableWatcherOptions<PS, M, T>,
   params: TableWatcherParams = { runOnInit: true },
-) => {
+): (() => void) => {
   const { world, table, onUpdate, onEnter, onExit, onChange } = options;
   if (!onUpdate && !onEnter && !onExit && !onChange) {
     throw new Error("At least one callback has to be provided");
   }
 
-  systems.defineTableSystem(
+  return systems.defineTableSystem(
     world ?? table.world,
     table,
     (_update) => {

--- a/src/tables/types.ts
+++ b/src/tables/types.ts
@@ -1,6 +1,6 @@
 import { Subject } from "rxjs";
 
-import type { TableMethodsWatcherOptions, TableWatcherParams } from "@/queries/types";
+import type { TableMethodsOnceOptions, TableMethodsWatcherOptions, TableWatcherParams } from "@/queries/types";
 import type { Entity, EntitySymbol } from "@/lib/external/mud/entity";
 import type {
   BaseTableMetadata,
@@ -601,6 +601,41 @@ export type TableBaseMethods<PS extends Schema, M extends BaseTableMetadata = Ba
    * @internal
    */
   watch: (options: TableMethodsWatcherOptions<PS, M, T>, params?: TableWatcherParams) => void;
+
+  /**
+   * Create a watcher that triggers `do` once `filter` returns true.
+   *
+   * This allows for a one-time trigger, based on some condition checked against the updates.
+   * The watcher will automatically unsubscribe after the first trigger.
+   *
+   * @param options The {@link TableMethodsOnceOptions} for creating the table watcher.
+   * - `world` The RECS world containing the table to watch (optional, default global world).
+   * - `filter` The condition to check against the updates.
+   * - `do` Callback triggered when the condition is met.
+   * @param params Additional {@link TableWatcherParams} for the watcher.
+   * @example
+   * This example creates a watcher for the "Player" table that triggers once the score of a player is 100 or more.
+   *
+   * ```ts
+   * const { tables } = createWrapper({ world, mudConfig });
+   * tables.Player.set({ score: 50 }, playerRecord);
+   *
+   * tables.Player.once({
+   *   filter: (update) => update.properties.current?.score >= 100,
+   *   do: (update) => console.log(update),
+   * });
+   * // no output
+   *
+   * tables.Player.update({ score: 100 }, playerRecord);
+   * // -> { table: tables.Player, entity: playerRecord, current: { score: 100 }, prev: { score: 50 }, type: "update" }
+   *
+   * tables.Player.set({ score: 100 }, otherPlayerRecord);
+   * // no output, since the subscription was disposed after the first trigger
+   * ```
+   * @category Methods
+   * @internal
+   */
+  once: (options: TableMethodsOnceOptions<PS, M, T>, params?: TableWatcherParams) => void;
 };
 
 /**


### PR DESCRIPTION
Add a table.once method, similar to table.watch, except that it will unsubscribe from the system after a condition is met.

```ts
tables.Player.once({
  filter: (update) => update.properties.score >= 100,
  do: (update) => rewardPlayer(update.entity, update.properties.score),
})
```

This is especially useful for local tables, e.g. with a table used for aggregating pending transactions, as we can then react to the table updating the status for a specific entity, and automatically dispose of the listener as the entity exits the table.