### PR TITLE
Small fixes

### DIFF
--- a/src/adapter/encoder.ts
+++ b/src/adapter/encoder.ts
@@ -103,6 +103,9 @@ export const encodeField = <TSchemaAbiType extends SchemaAbiType>(
  * @category Schema
  */
 export const encodeKeys = (abiKeySchema: AbiKeySchema, keys: Properties<AbiToSchema<AbiKeySchema>>): Hex[] => {
-  const staticFields = Object.values(abiKeySchema).filter(isStaticAbiType);
-  return Object.values(keys).map((key, index) => encodeAbiParameters([{ type: staticFields[index] }], [key]));
+  // sort both properties because they might be provided in a different order
+  const staticFields = Object.values(abiKeySchema).filter(isStaticAbiType).sort();
+  const sortedKeys = Object.values(keys).sort();
+
+  return Object.values(sortedKeys).map((key, index) => encodeAbiParameters([{ type: staticFields[index] }], [key]));
 };

--- a/src/tables/core/createTable.ts
+++ b/src/tables/core/createTable.ts
@@ -62,12 +62,14 @@ export const createTable = <PS extends Schema, M extends BaseTableMetadata, P ex
   const id = options?.id ?? uuid();
   const baseMetadata = options?.metadata ?? {};
   const indexed = options?.indexed ?? false;
-  const persist = options?.persist ?? false;
+  let persist = options?.persist ?? false;
   const version = options?.version ?? DEFAULT_VERSION;
   const storageAdapter = options?.storageAdapter ?? createLocalStorageAdapter();
 
-  if (persist && typeof window === "undefined")
-    throw new Error("Tables cannot be persisted in a non-browser environment");
+  if (persist && typeof window === "undefined") {
+    persist = false;
+    console.warn("Tables will not be persisted in a non-browser environment");
+  }
   if (persist && !options?.id) throw new Error("You must provide an id for a table to be persisted");
 
   // Metadata


### PR DESCRIPTION
- don’t persist tables on node (`createTable` → console warn and force persist false)
- fix `encodeKeys` issue where provided keys and key schema don’t have the sames properties order (sort it before encoding)